### PR TITLE
[http] Use datasource's `fetcher_kwargs`

### DIFF
--- a/peakina/io/http/http_fetcher.py
+++ b/peakina/io/http/http_fetcher.py
@@ -16,7 +16,7 @@ class HttpFetcher(Fetcher):
         super().__init__(*args, **kwargs)
 
     def open(self, filepath, **fetcher_kwargs) -> IO:
-        r = self.pool_manager.request('GET', filepath, preload_content=False)
+        r = self.pool_manager.request('GET', filepath, preload_content=False, **fetcher_kwargs)
         ret = tempfile.NamedTemporaryFile(suffix='.httptmp')
         for chunk in r.stream():
             ret.write(chunk)

--- a/tests/io/http/test_http_fetcher.py
+++ b/tests/io/http/test_http_fetcher.py
@@ -24,3 +24,13 @@ def test_http_mtime_error(mocker):
     fetcher = HttpFetcher('')
     mocker.patch.object(fetcher.pool_manager, 'request').side_effect = TimeoutError
     assert fetcher.mtime('') is None
+
+
+def test_http_fetcher_kwargs(http_path, mocker):
+    """It should pass fetcher_kwargs to `pool_manager.request`"""
+    fetcher = HttpFetcher('')
+    request_mock = mocker.patch.object(fetcher.pool_manager, 'request')
+    fetcher.open(http_path, headers={'X-Foo': 'bar'})
+    request_mock.assert_called_once_with(
+        'GET', http_path, preload_content=False, headers={'X-Foo': 'bar'}
+    )


### PR DESCRIPTION
If the datasource defines a custom `fetcher_kwargs` field, e.g.
`{'headers': {'Accept': 'application/json'}}`, it should be passed down
to the `request` method of `urllib3`'s requester.

Closes #18