### PR TITLE
Fix :: s3 listdir with subdirectories

### DIFF
--- a/peakina/io/s3/s3_fetcher.py
+++ b/peakina/io/s3/s3_fetcher.py
@@ -10,9 +10,9 @@ class S3Fetcher(Fetcher):
     def __init__(self, *, client_kwargs: Optional[Dict[str, Any]] = None, **kwargs):
         super().__init__(**kwargs)
         self.client_kwargs = client_kwargs
-        self._mtimes_cache: Dict[str, Dict[str, int]] = {}
+        self._mtimes_cache: Dict[str, Dict[str, Optional[int]]] = {}
 
-    def get_dir_mtimes(self, dirpath: str) -> Dict[str, int]:
+    def get_dir_mtimes(self, dirpath: str) -> Dict[str, Optional[int]]:
         if dirpath not in self._mtimes_cache:
             self._mtimes_cache[dirpath] = dir_mtimes(dirpath, client_kwargs=self.client_kwargs)
         return self._mtimes_cache[dirpath]

--- a/peakina/io/s3/s3_utils.py
+++ b/peakina/io/s3/s3_utils.py
@@ -19,6 +19,7 @@ def parse_s3_url(url: str, file=True) -> Tuple[Optional[str], Optional[str], Opt
 
     Args:
         url (str): the s3 url
+        file (bool): whether or not the url is a file url or a directory one
 
     Returns:
         tuple: (access_key, secret, bucketname, objectname). If credentials
@@ -73,10 +74,12 @@ def s3_mtime(url: str, *, client_kwargs: Optional[Dict[str, Any]] = None) -> Opt
 
 
 def dir_mtimes(
-    url: str, *, client_kwargs: Optional[Dict[str, Any]] = None
+    dirpath: str, *, client_kwargs: Optional[Dict[str, Any]] = None
 ) -> Dict[str, Optional[int]]:
-    access_key, secret, bucketname, objectname = parse_s3_url(url, file=False)
+    access_key, secret, bucketname, objectname = parse_s3_url(dirpath, file=False)
     fs = s3fs.S3FileSystem(key=access_key, secret=secret, client_kwargs=client_kwargs)
+    # objectname can be empty or not ('subdir1/subdir2')
+    bucketdir = f'{bucketname}/{objectname}'.rstrip('/')
     return {
-        re.sub(rf'^{bucketname}/', '', x['name']): _get_timestamp(x) for x in fs.listdir(bucketname)
+        re.sub(rf'^{bucketdir}/', '', x['name']): _get_timestamp(x) for x in fs.listdir(bucketdir)
     }

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     pydantic
     pyjq
     python-slugify
-    s3fs
+    s3fs==0.4.0
     tables
     urllib3
     xlrd

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,8 @@ def s3_endpoint_url(s3_container):
     s3_client.create_bucket(Bucket='mybucket')
     s3_client.upload_file('tests/fixtures/0_0.csv', 'mybucket', '0_0.csv')
     s3_client.upload_file('tests/fixtures/0_1.csv', 'mybucket', '0_1.csv')
+    s3_client.upload_file('tests/fixtures/0_0.csv', 'mybucket', 'mydir/0_0.csv')
+    s3_client.upload_file('tests/fixtures/0_1.csv', 'mybucket', 'mydir/0_1.csv')
     return s3_url
 
 

--- a/tests/io/s3/test_s3_fetcher.py
+++ b/tests/io/s3/test_s3_fetcher.py
@@ -23,8 +23,11 @@ def test_s3_fetcher_listdir(s3_fetcher, mocker):
     assert s3_fetcher.listdir(dirpath) == [
         '0_0.csv',
         '0_1.csv',
+        'mydir',
     ]
+
     assert s3_fetcher.mtime(f'{dirpath}/0_0.csv') > 0
+    assert s3_fetcher.mtime(f'{dirpath}/mydir') is None
     s3_mtime_mock.assert_not_called()
 
 

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -134,6 +134,14 @@ def test_s3(s3_endpoint_url):
     )
     assert ds.get_df().shape == (4, 3)
 
+    # With subdirectories
+    ds = DataSource(
+        f'{dirpath}/mydir/0_*.csv',
+        match='glob',
+        fetcher_kwargs={'client_kwargs': {'endpoint_url': s3_endpoint_url}},
+    )
+    assert ds.get_df().shape == (4, 3)
+
 
 def test_basic_excel(path):
     """It should not add a __sheet__ column when retrieving a single sheet"""


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

When listing a directory, we would use the bucketname instead of the whole path making `match` fail if the path was `bucketname/dir/myfile*.csv` for example.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
