### PR TITLE
Fix: pd.read_paquet should always use fastparquet

### DIFF
--- a/peakina/helpers.py
+++ b/peakina/helpers.py
@@ -55,7 +55,7 @@ SUPPORTED_FILE_TYPES = {
         read_json,
         ['filter'],  # this option comes from read_json, which @wraps(pd.read_json)
     ),
-    'parquet': TypeInfos(['peakina/parquet'], pd.read_parquet),
+    'parquet': TypeInfos(['peakina/parquet'], lambda x: pd.read_parquet(x, engine='fastparquet')),
     'xml': TypeInfos(['application/xml'], read_xml),
 }
 


### PR DESCRIPTION
We install only `fastparquet` package as `pyarrow` has been juged too big

This is to avoid the following error:
```
File \"/app/venv/lib/python3.6/site-packages/peakina/helpers.py\", line 176, in pd_read return SUPPORTED_FILE_TYPES[t].reader(filepath, **kwargs) File \"/app/venv/lib/python3.6/site-packages/pandas/io/parquet.py\", line 309, in read_parquet impl = get_engine(engine) 
File \"/app/venv/lib/python3.6/site-packages/pandas/io/parquet.py\", line 33, in get_engine \"Unable to find a usable engine; \" ImportError: Unable to find a usable engine; tried using: 'pyarrow', 'fastparquet'. pyarrow or fastparquet is required for parquet suppor
I
```