### PR TITLE
Fix :: ftp and ftps should be resilient to quit() errors

### DIFF
--- a/peakina/io/ftp/ftp_utils.py
+++ b/peakina/io/ftp/ftp_utils.py
@@ -4,7 +4,7 @@ import re
 import socket
 import ssl
 import tempfile
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from datetime import datetime
 from functools import partial
 from os.path import basename, join
@@ -44,7 +44,8 @@ def ftps_client(params: ParseResult):
         yield ftps, params.path
 
     finally:
-        ftps.quit()
+        with suppress(Exception):
+            ftps.quit()
 
 
 @contextmanager
@@ -57,7 +58,8 @@ def ftp_client(params: ParseResult):
         yield ftp, params.path
 
     finally:
-        ftp.quit()
+        with suppress(Exception):
+            ftp.quit()
 
 
 @contextmanager

--- a/tests/io/ftp/test_ftp_utils.py
+++ b/tests/io/ftp/test_ftp_utils.py
@@ -106,6 +106,15 @@ def test_ftp_client(mocker):
     mock_ftp_client.quit.assert_called_once()
 
 
+def test_ftp_client_quit_resilience(mocker):
+    mock_ftp_client = mocker.patch('ftplib.FTP').return_value
+    mock_ftp_client.quit.side_effect = Exception('test')
+
+    ftp_open('ftp://sacha@ondine.com:123/picha/chu.csv')  # Should not crash
+
+    mock_ftp_client.quit.assert_called_once()
+
+
 def test_ftps_client(mocker):
     mock_ftps_client = mocker.patch('peakina.io.ftp.ftp_utils.FTPS').return_value
     url = 'ftps://sacha@ondine.com:123/picha/chu.csv'
@@ -113,6 +122,15 @@ def test_ftps_client(mocker):
 
     mock_ftps_client.connect.assert_called_once_with(host='ondine.com', port=123, timeout=3)
     mock_ftps_client.login.assert_called_once_with(passwd='', user='sacha')
+    mock_ftps_client.quit.assert_called_once()
+
+
+def test_ftps_client_quit_resilience(mocker):
+    mock_ftps_client = mocker.patch('peakina.io.ftp.ftp_utils.FTPS').return_value
+    mock_ftps_client.quit.side_effect = Exception('test')
+
+    ftp_open('ftps://sacha@ondine.com:123/picha/chu.csv')  # Should not crash
+
     mock_ftps_client.quit.assert_called_once()
 
 

--- a/tests/io/ftp/test_ftp_utils.py
+++ b/tests/io/ftp/test_ftp_utils.py
@@ -107,10 +107,11 @@ def test_ftp_client(mocker):
 
 
 def test_ftp_client_quit_resilience(mocker):
+    """it should never crash on ftp connection teardown"""
     mock_ftp_client = mocker.patch('ftplib.FTP').return_value
     mock_ftp_client.quit.side_effect = Exception('test')
 
-    ftp_open('ftp://sacha@ondine.com:123/picha/chu.csv')  # Should not crash
+    ftp_open('ftp://sacha@ondine.com:123/picha/chu.csv')
 
     mock_ftp_client.quit.assert_called_once()
 


### PR DESCRIPTION
## Change Summary
Fixes an error in the finally block, when the connection was in an erroneous state (for example bad credentials).

Typical stack is:
```
Traceback (most recent call last):
  File “/Users/wgorge/dev/laputa/venv/lib/python3.6/site-packages/peakina/io/ftp/ftp_utils.py”, line 41, in ftps_client
    ftps.connect(host=params.hostname or ‘’, port=params.port, timeout=3)
  File “/Users/wgorge/dev/laputa/venv/lib/python3.6/site-packages/peakina/io/ftp/ftp_utils.py”, line 27, in connect
    self.sock = socket.create_connection((self.host, self.port), self.timeout)
  File “/Users/wgorge/.pyenv/versions/3.6.7/lib/python3.6/socket.py”, line 724, in create_connection
    raise err
  File “/Users/wgorge/.pyenv/versions/3.6.7/lib/python3.6/socket.py”, line 713, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 61] Connection refused
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File “/Users/wgorge/dev/laputa/venv/lib/python3.6/site-packages/flask/app.py”, line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File “/Users/wgorge/dev/laputa/venv/lib/python3.6/site-packages/flask/app.py”, line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File “/Users/wgorge/dev/laputa/venv/lib/python3.6/site-packages/flask_restful/__init__.py”, line 458, in wrapper
    resp = resource(*args, **kwargs)
  File “/Users/wgorge/dev/laputa/venv/lib/python3.6/site-packages/flask/views.py”, line 89, in view
    return self.dispatch_request(*args, **kwargs)
  File “/Users/wgorge/dev/laputa/venv/lib/python3.6/site-packages/flask_restful/__init__.py”, line 573, in dispatch_request
    resp = meth(*args, **kwargs)
  File “/Users/wgorge/dev/laputa/laputa/api/nocache.py”, line 10, in func_no_cache
    response = func(*args, **kwargs)
  File “/Users/wgorge/dev/laputa/laputa/api/access_control.py”, line 365, in func_with_permission_check
    return func(*args, **kwargs)
  File “/Users/wgorge/dev/laputa/laputa/api/resources/data.py”, line 902, in get
    return redact(g.small_app.list_data_sources_files())
  File “/Users/wgorge/dev/laputa/laputa/app/small_app.py”, line 1838, in list_data_sources_files
    return self.data_source_manager.list_data_sources_files(data_sources_specs)
  File “/Users/wgorge/dev/laputa/laputa/app/uploadable_data_manager.py”, line 176, in list_data_sources_files
    for f in ds.get_matched_datasources()
  File “/Users/wgorge/dev/laputa/laputa/app/uploadable_data_manager.py”, line 171, in <listcomp>
    {
  File “/Users/wgorge/dev/laputa/venv/lib/python3.6/site-packages/peakina/datasource.py”, line 122, in get_matched_datasources
    for uri in self.fetcher.get_filepath_list():
  File “/Users/wgorge/dev/laputa/venv/lib/python3.6/site-packages/peakina/io/fetcher.py”, line 90, in get_filepath_list
    all_filenames = self.listdir(self.dirpath)
  File “/Users/wgorge/dev/laputa/venv/lib/python3.6/site-packages/peakina/io/ftp/ftp_fetcher.py”, line 20, in listdir
    self._mtimes_cache = dir_mtimes(dirpath)
  File “/Users/wgorge/dev/laputa/venv/lib/python3.6/site-packages/peakina/io/ftp/ftp_utils.py”, line 176, in dir_mtimes
    with client(url) as (cl_ftp, path):
  File “/Users/wgorge/.pyenv/versions/3.6.7/lib/python3.6/contextlib.py”, line 81, in __enter__
    return next(self.gen)
  File “/Users/wgorge/dev/laputa/venv/lib/python3.6/site-packages/peakina/io/ftp/ftp_utils.py”, line 47, in ftps_client
    ftps.quit()
  File “/Users/wgorge/.pyenv/versions/3.6.7/lib/python3.6/ftplib.py”, line 665, in quit
    resp = self.voidcmd(‘QUIT’)
  File “/Users/wgorge/.pyenv/versions/3.6.7/lib/python3.6/ftplib.py”, line 277, in voidcmd
    self.putcmd(cmd)
  File “/Users/wgorge/.pyenv/versions/3.6.7/lib/python3.6/ftplib.py”, line 199, in putcmd
    self.putline(line)
  File “/Users/wgorge/.pyenv/versions/3.6.7/lib/python3.6/ftplib.py”, line 194, in putline
    self.sock.sendall(line.encode(self.encoding))
AttributeError: ‘NoneType’ object has no attribute ‘sendall’
```

The problem is that we don't get a classic the usual error class but another unrelated error.

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
