### PR TITLE
ci: pin xlrd version to <2 temporarily. 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ long-description-content-type = text/markdown; charset=UTF-8
 author = Toucan Toco
 author_email = dev@toucantoco.com
 url = https://github.com/ToucanToco/peakina
-version = 0.5.4
+version = 0.5.5
 license = BSD
 classifiers=
     Intended Audience :: Developers
@@ -30,7 +30,7 @@ install_requires =
     s3fs==0.4.0
     tables
     urllib3
-    xlrd
+    xlrd<2  # when pandas 1.2.0 is out, try with xlrd 2 + openpyxl ?
     xmltodict
 
 [options.packages.find]


### PR DESCRIPTION
Tests fails with xlrd 2, so I pin xlrd to `< 2`.
When pandas 1.2.0 is out, try with xlrd 2 + openpyxl.
More infos in https://pandas.pydata.org/pandas-docs/dev/reference/api/pandas.read_excel.html, `engine` kwarg doc.