### PR TITLE
chore(version): bump to v0.7.1 TCTC-1973

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "peakina"
-version = "0.7.0"
+version = "0.7.1"
 description = "pandas readers on steroids (remote files, glob patterns, cache, etc.)"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 readme = "README.md"
@@ -24,7 +24,7 @@ certifi = "^2021.10.8"
 chardet = "^4.0.0"
 fastparquet = "^0.8.0"
 jq = "^1.2.1"
-pandas = "^1.4.0"
+pandas = "^1.2.5"
 paramiko = "^2.9.2"
 pydantic = "^1.9.0"
 python-slugify = ">=5.0.2,<7.0.0"


### PR DESCRIPTION
## What
- downgrade pandas from 1.4.0 to 1.2.5 (to be support by laputa)
- bump a new version in the same occasion 0.7.0 => 0.7.1