### PR TITLE
fix: fix csv reader TCTC-1973

### DIFF
--- a/peakina/readers/csv.py
+++ b/peakina/readers/csv.py
@@ -11,9 +11,6 @@ if TYPE_CHECKING:
 
     FilePathOrBuffer = Union[str, bytes, PathLike[str], PathLike[bytes]]
 
-# The chunksize value for previews
-PREVIEW_CHUNK_SIZE = 1024
-
 
 @wraps(pd.read_csv)
 def read_csv(
@@ -37,9 +34,9 @@ def read_csv(
             # keep the first row 0 (as the header) and then skip everything else up to row `preview_offset`
             skiprows=range(1, preview_offset + 1),
             nrows=preview_nrows,
-            chunksize=PREVIEW_CHUNK_SIZE,
         )
-        return next(chunks)
+        # to prevent for the chunksize not present in params
+        return next(chunks) if not isinstance(chunks, pd.DataFrame) else chunks
 
     return pd.read_csv(
         filepath_or_buffer,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "peakina"
-version = "0.7.3"
+version = "0.7.4"
 description = "pandas readers on steroids (remote files, glob patterns, cache, etc.)"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 readme = "README.md"


### PR DESCRIPTION
## WHAT
- remove default preview chunksize because laputa is the one who decide for that value
- return an iterator only if the type of the reader is not a dataframe

## WHY
![Screenshot from 2022-03-02 14-57-46](https://user-images.githubusercontent.com/22576758/156375573-6ba90302-bace-455e-86b9-1238d149ea56.png)
