### PR TITLE
fix: on read csv chunks and indexError on excel TCTC-1973

### DIFF
--- a/peakina/readers/csv.py
+++ b/peakina/readers/csv.py
@@ -27,16 +27,21 @@ def read_csv(
     The read_csv method is able to make a preview by reading on chunks
     """
     if preview_nrows is not None or preview_offset:
+
+        if (nrows := kwargs.get("nrows")) is None:
+            nrows = preview_nrows
+        if (skiprows := kwargs.get("skiprows")) is None:
+            skiprows = range(1, preview_offset + 1)
+
         chunks = pd.read_csv(
             filepath_or_buffer,
             error_bad_lines=error_bad_lines,
             **kwargs,
             # keep the first row 0 (as the header) and then skip everything else up to row `preview_offset`
-            skiprows=range(1, preview_offset + 1),
-            nrows=preview_nrows,
+            skiprows=skiprows,
+            nrows=nrows,
         )
-        # to prevent for the chunksize not present in params
-        return next(chunks) if not isinstance(chunks, pd.DataFrame) else chunks
+        return chunks
 
     return pd.read_csv(
         filepath_or_buffer,

--- a/peakina/readers/csv.py
+++ b/peakina/readers/csv.py
@@ -28,8 +28,13 @@ def read_csv(
     """
     if preview_nrows is not None or preview_offset:
 
+        # In case we don't have the native nrows given in kwargs, we're going
+        # to use the provided preview_nrows
         if (nrows := kwargs.get("nrows")) is None:
             nrows = preview_nrows
+
+        # In case we don't have the native skiprows given in kwargs,
+        # we're going to use the provided preview_offset as range(1, preview_offset + 1)
         if (skiprows := kwargs.get("skiprows")) is None:
             skiprows = range(1, preview_offset + 1)
 
@@ -41,6 +46,9 @@ def read_csv(
             skiprows=skiprows,
             nrows=nrows,
         )
+        # if the chunksize is not in kwargs, we want to return the iterator
+        if kwargs.get("chunksize") is None:
+            return next(chunks) if not isinstance(chunks, pd.DataFrame) else chunks
         return chunks
 
     return pd.read_csv(

--- a/peakina/readers/excel.py
+++ b/peakina/readers/excel.py
@@ -37,7 +37,10 @@ def _old_xls_rows_iterator(
         to_iter = range(wb.sheet_by_name(sh_name).nrows)
 
     for rx in to_iter:
-        yield wb.sheet_by_name(sh_name).row(rx)
+        try:
+            yield wb.sheet_by_name(sh_name).row(rx)
+        except IndexError:
+            break
 
 
 def _new_xls_rows_iterator(

--- a/peakina/readers/xml.py
+++ b/peakina/readers/xml.py
@@ -32,9 +32,13 @@ def transform_with_jq(data: Any, jq_filter: str) -> Union[PdDataList, PdDataDict
 def read_xml(
     filepath: str,
     encoding: str = "utf-8",
+    preview_offset: int = 0,
+    preview_nrows: Optional[int] = None,
     filter: Optional[str] = None,
 ) -> pd.DataFrame:
     data = xmltodict.parse(open(filepath).read(), encoding=encoding)
     if filter is not None:
         data = transform_with_jq(data, filter)
+    if isinstance(data, list) and isinstance(preview_nrows, int):
+        data = data[preview_offset : preview_nrows + preview_offset]
     return pd.DataFrame(data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "peakina"
-version = "0.7.4"
+version = "0.7.5"
 description = "pandas readers on steroids (remote files, glob patterns, cache, etc.)"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 readme = "README.md"

--- a/tests/readers/test_csv.py
+++ b/tests/readers/test_csv.py
@@ -138,3 +138,31 @@ def test_csv_metadata(path):
         "df_rows": 12,
         "total_rows": 12,
     }
+
+
+def test_chunk_and_preview(path):
+    """It should be able to retrieve a dataframe with chunks"""
+    ds = DataSource(path("0_0.csv"), reader_kwargs={"chunksize": 1, "preview_nrows": 1})
+    assert ds.get_df().shape == (1, 2)
+
+    # with nrows and offset
+    ds = DataSource(
+        path("fixture-1.csv"),
+        reader_kwargs={"chunksize": 3, "preview_nrows": 2, "preview_offset": 2},
+    )
+    assert ds.get_df().shape == (2, 2)
+    assert ds.get_metadata() == {
+        "df_rows": 2,
+        "total_rows": 12,
+    }
+
+    # we equest 15 lines and we can got only 12 as it's the maximum amount of rows we have
+    ds = DataSource(
+        path("fixture-1.csv"),
+        reader_kwargs={"chunksize": 7, "preview_nrows": 15},
+    )
+    assert ds.get_df().shape == (12, 2)
+    assert ds.get_metadata() == {
+        "df_rows": 12,
+        "total_rows": 12,
+    }

--- a/tests/readers/test_excel.py
+++ b/tests/readers/test_excel.py
@@ -226,6 +226,27 @@ def test_multisheet_xlsx(path):
     )
 
 
+def test_preview_sheet_more_lines_xlsx(path):
+    """It should not fail with an 'IndexError' when preview_nrows is bigger than the real amount of rows"""
+    ds = DataSource(
+        path("fixture.xls"),
+        reader_kwargs={"preview_nrows": 2000, "preview_offset": 2},
+    )
+    assert ds.get_df().shape == (168, 6)
+    assert ds.get_metadata() == {
+        "sheetnames": ["Data"],
+        "df_rows": 168,
+        "total_rows": 170,
+    }
+
+    ds = DataSource(
+        path("fixture-multi-sheet.xlsx"),
+        reader_kwargs={"sheet_name": "February", "preview_offset": 0, "preview_nrows": 1000},
+    )
+    # because our excel file has 1 entry on January sheet and 3 entries in February sheet
+    assert ds.get_df().equals(pd.DataFrame({"Month": [2, 3, 4], "Year": [2019, 2021, 2022]}))
+
+
 def test_with_specials_types_xlsx(path):
     """It should be able to read sheet and format types"""
     ds = DataSource(

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -232,6 +232,11 @@ def test_basic_xml(path):
     df = pd.DataFrame({"@id": [1, 2], "title": ["Keep on dancin'", "Small Talk"]})
     assert ds.get_df().equals(df)
 
+    jq_filter = '.records .record[] | .["@id"]|=tonumber'
+    ds = DataSource(path("fixture.xml"), reader_kwargs={"filter": jq_filter, "preview_nrows": 1})
+    df = pd.DataFrame({"@id": [1], "title": ["Keep on dancin'"]})
+    assert ds.get_df().equals(df)
+
 
 def test_basic_json(path):
     """It should apply optional jq filter when extracting a json datasource"""


### PR DESCRIPTION
## WHAT

During laputa integration, we needed to fix some errors during tests.

## WHY

-  fix on read_csv for the iterator + added tests to handle chunksize and preview_nrows as params
![Screenshot from 2022-03-02 15-29-47](https://user-images.githubusercontent.com/22576758/156409912-9a4b905c-c092-4a59-9ea9-6efcd762997b.png)

-  fix/catch IndexError when the preview_nrows is upper than all the available row
![Screenshot from 2022-03-02 17-27-37](https://user-images.githubusercontent.com/22576758/156409983-8f970897-34dd-4e1a-af22-4c6b59268d54.png)

- fix retrocompatibility with read_xml
![Screenshot from 2022-03-02 17-41-24](https://user-images.githubusercontent.com/22576758/156410053-2f3d48c4-b7f4-4ce0-acd9-85143efe2c12.png)

-  bump from 0.7.4 to 0.7.5