### PR TITLE
fix: fix retrocompatibility for read_json TCTC-1973

### DIFF
--- a/peakina/readers/json.py
+++ b/peakina/readers/json.py
@@ -24,6 +24,8 @@ def read_json(
     path_or_buf: "FilePathOrBuffer",
     encoding: str = "utf-8",
     filter: Optional[str] = None,
+    preview_offset: int = 0,
+    preview_nrows: Optional[int] = None,
     *args: Any,
     **kwargs: Any,
 ) -> pd.DataFrame:

--- a/peakina/readers/json.py
+++ b/peakina/readers/json.py
@@ -32,4 +32,14 @@ def read_json(
     if filter is not None:
         with open(path_or_buf, encoding=encoding) as f:
             path_or_buf = transform_with_jq(f.read(), filter)
+
+    # for the preview_nrows and the preview_offset, we're going to convert in to list here
+    if preview_nrows is not None:
+        # In case we don't have the native nrows given in kwargs, we're going
+        # to use the provided preview_nrows
+        if (nrows := kwargs.get("nrows")) is None:
+            nrows = preview_nrows
+
+        kwargs["nrows"] = nrows
+
     return pd.read_json(path_or_buf, encoding=encoding, *args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "peakina"
-version = "0.7.5"
+version = "0.7.6"
 description = "pandas readers on steroids (remote files, glob patterns, cache, etc.)"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 readme = "README.md"

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -248,6 +248,14 @@ def test_basic_json(path):
     df = pd.DataFrame({"@id": [1, 2], "title": ["Keep on dancin'", "Small Talk"]})
     assert ds.get_df().equals(df)
 
+    jq_filter = '.records .record[] | .["@id"]|=tonumber'
+    ds = DataSource(
+        path("fixture.json"),
+        reader_kwargs={"filter": jq_filter, "lines": True, "preview_nrows": 1},
+    )
+    df = pd.DataFrame({"@id": [1], "title": ["Keep on dancin'"]})
+    assert ds.get_df().equals(df)
+
 
 def test_basic_parquet(path):
     """It should open a basic parquet file"""


### PR DESCRIPTION
## WHAT

- Fix retro-compatibility for read_json on laputa
![Screenshot from 2022-03-02 18-40-07](https://user-images.githubusercontent.com/22576758/156417542-293ce057-9994-468d-bfd8-4b2877f9acca.png)

- handle preview_nrows from read_json]

- added a new test for read_json with preview_nrows

- bump from 0.7.5 to 0.7.6