### PR TITLE
fix: read_json for edges cases between nrows, lines=True TCTC-1973

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "peakina"
-version = "0.7.6"
+version = "0.7.7"
 description = "pandas readers on steroids (remote files, glob patterns, cache, etc.)"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 readme = "README.md"

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -248,13 +248,18 @@ def test_basic_json(path):
     df = pd.DataFrame({"@id": [1, 2], "title": ["Keep on dancin'", "Small Talk"]})
     assert ds.get_df().equals(df)
 
-    jq_filter = '.records .record[] | .["@id"]|=tonumber'
     ds = DataSource(
         path("fixture.json"),
         reader_kwargs={"filter": jq_filter, "lines": True, "preview_nrows": 1},
     )
     df = pd.DataFrame({"@id": [1], "title": ["Keep on dancin'"]})
     assert ds.get_df().equals(df)
+
+    ds = DataSource(
+        path("fixture.json"),
+        reader_kwargs={"preview_nrows": 1},
+    )
+    assert ds.get_df().shape == (1, 1)
 
 
 def test_basic_parquet(path):


### PR DESCRIPTION
## WHAT

- fix retro-compatibility with read_json
- handle edge cases with nrows and 'lines=True/False'
- added tests for the json reader

![Screenshot from 2022-03-03 11-06-41](https://user-images.githubusercontent.com/22576758/156562044-797d1530-7b84-4e30-acd7-e6245f7fd3ce.png)

