### PR TITLE
fix: fix duplocations on params given

### DIFF
--- a/peakina/readers/csv.py
+++ b/peakina/readers/csv.py
@@ -27,10 +27,14 @@ def read_csv(
     The read_csv method is able to make a preview by reading on chunks
     """
     if preview_nrows is not None or preview_offset:
+        if (skipfooter := kwargs.pop("skipfooter", None)) is None:
+            skipfooter = 0
 
         # In case we don't have the native nrows given in kwargs, we're going
         # to use the provided preview_nrows
-        if (nrows := kwargs.pop("nrows", None)) is None:
+        # and skipfooter should be equal to 0 because of this:
+        # cf : https://github.com/pandas-dev/pandas/blob/31c553f1e599e2695a33236e02511c2841ac9aa0/pandas/io/parsers/readers.py#L2209
+        if (nrows := kwargs.pop("nrows", None)) is None and skipfooter == 0:
             nrows = preview_nrows
 
         # In case we don't have the native skiprows given in kwargs,
@@ -44,6 +48,7 @@ def read_csv(
             **kwargs,
             # keep the first row 0 (as the header) and then skip everything else up to row `preview_offset`
             skiprows=skiprows,
+            skipfooter=skipfooter,
             nrows=nrows,
         )
         # if the chunksize is not in kwargs, we want to return the iterator

--- a/peakina/readers/csv.py
+++ b/peakina/readers/csv.py
@@ -30,12 +30,12 @@ def read_csv(
 
         # In case we don't have the native nrows given in kwargs, we're going
         # to use the provided preview_nrows
-        if (nrows := kwargs.get("nrows")) is None:
+        if (nrows := kwargs.pop("nrows", None)) is None:
             nrows = preview_nrows
 
         # In case we don't have the native skiprows given in kwargs,
         # we're going to use the provided preview_offset as range(1, preview_offset + 1)
-        if (skiprows := kwargs.get("skiprows")) is None:
+        if (skiprows := kwargs.pop("skiprows", None)) is None:
             skiprows = range(1, preview_offset + 1)
 
         chunks = pd.read_csv(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "peakina"
-version = "0.7.7"
+version = "0.7.8"
 description = "pandas readers on steroids (remote files, glob patterns, cache, etc.)"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 readme = "README.md"


### PR DESCRIPTION
## WHAT

- fix read_csv for duplication on natives params like nrows/skiprows
![Screenshot from 2022-03-03 23-41-45](https://user-images.githubusercontent.com/22576758/156666111-6dcf8f18-832f-47c4-a54d-dc9804bab2ac.png)

- fix nrows and skipfooter compatibilities
![Screenshot from 2022-03-04 01-38-54](https://user-images.githubusercontent.com/22576758/156677861-2ee3af9c-7928-4815-b8ea-1bea207f7a6c.png)

- a bump from 0.7.7 to 0.7.8