### PR TITLE
fix(excel reader): dtype param excel

### DIFF
--- a/peakina/readers/excel.py
+++ b/peakina/readers/excel.py
@@ -232,6 +232,7 @@ def read_excel(
     skiprows: Optional[int] = None,
     nrows: Optional[int] = None,
     skipfooter: int = 0,
+    dtype: Optional[dict] = {}
 ) -> pd.DataFrame:
     """
     Uses openpyxl (with xlrd as fallback) to convert the excel sheet into a csv string.
@@ -291,6 +292,7 @@ def read_excel(
         true_values=["True"],
         false_values=["False"],
         **columns_kwargs,
+        dtype=dtype
     )
 
 

--- a/peakina/readers/excel.py
+++ b/peakina/readers/excel.py
@@ -232,7 +232,7 @@ def read_excel(
     skiprows: Optional[int] = None,
     nrows: Optional[int] = None,
     skipfooter: int = 0,
-    dtype: Optional[dict] = {}
+    dtype: Optional[Dict[str, str]] = {},
 ) -> pd.DataFrame:
     """
     Uses openpyxl (with xlrd as fallback) to convert the excel sheet into a csv string.
@@ -292,7 +292,7 @@ def read_excel(
         true_values=["True"],
         false_values=["False"],
         **columns_kwargs,
-        dtype=dtype
+        dtype=dtype,
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "peakina"
-version = "0.7.9"
+version = "0.7.10"
 description = "pandas readers on steroids (remote files, glob patterns, cache, etc.)"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 readme = "README.md"

--- a/tests/readers/test_excel.py
+++ b/tests/readers/test_excel.py
@@ -262,3 +262,12 @@ def test_with_specials_types_xlsx(path):
             }
         )
     )
+
+
+def test_read_with_dtype(path):
+    """Chech that read exel is able to handle provided dtypes"""
+    ds = DataSource(
+        path("fixture-single-sheet.xlsx"),
+        reader_kwargs={'dtype': {'Month': 'str', 'Year': 'str'}}
+    )
+    assert isinstance(ds.get_df()['Month'][0], str)

--- a/tests/readers/test_excel.py
+++ b/tests/readers/test_excel.py
@@ -267,7 +267,6 @@ def test_with_specials_types_xlsx(path):
 def test_read_with_dtype(path):
     """Chech that read exel is able to handle provided dtypes"""
     ds = DataSource(
-        path("fixture-single-sheet.xlsx"),
-        reader_kwargs={'dtype': {'Month': 'str', 'Year': 'str'}}
+        path("fixture-single-sheet.xlsx"), reader_kwargs={"dtype": {"Month": "str", "Year": "str"}}
     )
-    assert isinstance(ds.get_df()['Month'][0], str)
+    assert isinstance(ds.get_df()["Month"][0], str)


### PR DESCRIPTION
## Change Summary

* Allow dtype param in Peakina's `read_excel`

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
