### PR TITLE
fix(excel): meta info for a single sheet

### DIFF
--- a/peakina/readers/excel.py
+++ b/peakina/readers/excel.py
@@ -42,7 +42,7 @@ def excel_meta(filepath: str, reader_kwargs: Dict[str, Any]) -> Dict[str, Any]:
 
     df = read_excel(excel_file, **reader_kwargs)
 
-    if sheet_name := reader_kwargs.get("sheet_name") is None:
+    if (sheet_name := reader_kwargs.get("sheet_name")) is None:
         # multiple sheets together
         total_rows = sum(excel_file.parse(sheet_name).shape[0] for sheet_name in sheet_names)
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "peakina"
-version = "0.7.11"
+version = "0.7.12"
 description = "pandas readers on steroids (remote files, glob patterns, cache, etc.)"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 readme = "README.md"

--- a/tests/readers/test_excel.py
+++ b/tests/readers/test_excel.py
@@ -112,7 +112,7 @@ def test_xls_metadata(path):
 
 def test_multiple_xls_metadata(path):
     """It should be able to get metadata of an excel file with multiple sheets"""
-    # with multiple sheets
+    # for all sheets
     ds = DataSource(
         path("fixture-multi-sheet.xlsx"),
         reader_kwargs={"sheet_name": None, "preview_nrows": 1, "preview_offset": 1},
@@ -148,6 +148,18 @@ def test_multiple_xls_metadata(path):
         "sheetnames": ["January", "February"],
         "df_rows": 2,
         "total_rows": 4,
+    }
+
+    # for a specific sheet (not the first one)
+    ds = DataSource(
+        path("fixture-multi-sheet.xlsx"),
+        reader_kwargs={"sheet_name": "February"},
+    )
+    assert ds.get_df().shape == (3, 2)
+    assert ds.get_metadata() == {
+        "sheetnames": ["January", "February"],
+        "df_rows": 3,
+        "total_rows": 3,
     }
 
 


### PR DESCRIPTION
As we forgot some parenthesese, the sheet_name variable was always
False, and that means only the first sheet meta were used
