### PR TITLE
fix: change default encoding for read_csv to None

### DIFF
--- a/peakina/datasource.py
+++ b/peakina/datasource.py
@@ -90,7 +90,7 @@ class DataSource:
         allowed_params = get_reader_allowed_params(filetype)
 
         # Check encoding
-        encoding = kwargs.get("encoding", "utf-8")
+        encoding = kwargs.get("encoding", None)
         if "encoding" in allowed_params:
             if not validate_encoding(stream.name, encoding):
                 encoding = detect_encoding(stream.name)

--- a/peakina/helpers.py
+++ b/peakina/helpers.py
@@ -145,7 +145,7 @@ def detect_sep(filepath: str, encoding: Optional[str] = None) -> str:
     return csv.Sniffer().sniff(str_head(filepath, 100, encoding)).delimiter
 
 
-def validate_sep(filepath: str, sep: str = ",", encoding: str = "utf-8") -> bool:
+def validate_sep(filepath: str, sep: str = ",", encoding: Optional[str] = None) -> bool:
     """
     Validates if the `sep` is a right separator of a CSV file
     (i.e. the dataframe has more than one column).


### PR DESCRIPTION

## Change Summary
Changing from default encoding `utf-8` to `None` because the encoding error handling is different in pandas 1.2 
if encoding is specified -> errors handler is strict
if encoding is None -> error handler doesnt throw (replace)

This caused errors to be thrown when they used to be ignored and breaks some datasource pipes.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
