### PR TITLE
refactor: remove useless extra params for `read_excel`

### DIFF
--- a/peakina/helpers.py
+++ b/peakina/helpers.py
@@ -59,7 +59,7 @@ SUPPORTED_FILE_TYPES = {
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         ],
         read_excel,
-        ["encoding", "decimal"],
+        [],
         excel_meta,
     ),
     "json": TypeInfos(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -96,7 +96,12 @@ def test_validate_sep_error(path):
         (TypeEnum.CSV, {"sheet_name": 0}, "Unsupported kwargs: 'sheet_name'"),
         (TypeEnum.CSV, {"skipfooter": 2}, None),
         (None, {"sheet_name": 0}, None),
-        (TypeEnum.EXCEL, {"keep_default_na": False, "encoding": "utf-8", "decimal": "."}, None),
+        (
+            TypeEnum.EXCEL,
+            {"keep_default_na": False, "encoding": "utf-8"},
+            "Unsupported kwargs: 'encoding'",
+        ),
+        (TypeEnum.EXCEL, {"keep_default_na": False, "decimal": "."}, None),
         (TypeEnum.EXCEL, {"skipfooter": 2}, None),
         (TypeEnum.XML, {"filter": "."}, None),
     ],


### PR DESCRIPTION
closes #80