### PR TITLE
Fix `helpers.detect_type`

### DIFF
--- a/peakina/helpers.py
+++ b/peakina/helpers.py
@@ -73,7 +73,7 @@ SUPPORTED_FILE_TYPES = {
         ["filter"],  # this option comes from read_json, which @wraps(pd.read_json)
     ),
     "parquet": TypeInfos(["peakina/parquet"], pd.read_parquet),
-    "xml": TypeInfos(["application/xml"], read_xml),
+    "xml": TypeInfos(["application/xml", "text/xml"], read_xml),
 }
 
 

--- a/peakina/helpers.py
+++ b/peakina/helpers.py
@@ -97,6 +97,10 @@ def detect_type(filepath: str, is_regex: bool = False) -> Optional[TypeEnum]:
     if is_regex:
         filepath = filepath.rstrip("$")
     mimetype, _ = mimetypes.guess_type(filepath)
+
+    if mimetype in ("application/geo+json", "application/vnd.geo+json"):
+        return TypeEnum.GEODATA
+
     # Fallback on custom MIME types
     if mimetype is None:
         _, fileext = os.path.splitext(filepath)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, Optional
+from unittest import mock
 
 import pytest
 
@@ -17,11 +18,19 @@ from peakina.helpers import (
 )
 
 
+def test_detect_geojson_type_for_coverage():
+    """Since the mimetypes module reads system files such as /etc/mime.types, It may or may
+    not return geojson mimetypes, depending on the environment. This test ensures coverage."""
+    with mock.patch("mimetypes.guess_type", return_value=("application/geo+json", None)):
+        assert detect_type("file.geojson") == "geodata"
+
+
 def test_detect_type_no_regex():
     """It should find the right type of a file and raise an exception if not supported"""
     assert detect_type("file.csv") == "csv"
     assert detect_type("file.tsv") == "csv"
     assert detect_type("file.xml") == "xml"
+    assert detect_type("file.geojson") == "geodata"
     with pytest.raises(ValueError) as e:
         detect_type("file.doc")
     assert (


### PR DESCRIPTION
## Change Summary

* `mimetypes.guess_type` returns `text/xml` for `.xml` files, so that mimetype needed to be supported
* Return `GEODATA` if a geojson-like mimetype is detected

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
