### PR TITLE
feat: share mtime cache between same ftp fetchers [TCTC-4687]

### DIFF
--- a/peakina/cache.py
+++ b/peakina/cache.py
@@ -2,8 +2,9 @@ from abc import ABCMeta, abstractmethod
 from contextlib import suppress
 from datetime import timedelta
 from enum import Enum
+from functools import lru_cache, wraps
 from pathlib import Path
-from time import time
+from time import monotonic_ns, time
 from typing import Any, TypedDict
 
 import pandas as pd
@@ -158,3 +159,39 @@ class HDFCache(Cache):
         self.set_metadata(metadata)
         with suppress(FileNotFoundError):
             (self.cache_dir / key).unlink()
+
+
+# taken from https://gist.github.com/Morreski/c1d08a3afa4040815eafd3891e16b945
+def timed_lru_cache(
+    _func: Any = None, *, seconds: int = 600, maxsize: int = 128, typed: bool = False
+) -> Any:
+    """Extension of functools lru_cache with a timeout
+
+    Parameters:
+    seconds (int): Timeout in seconds to clear the WHOLE cache, default = 10 minutes
+    maxsize (int): Maximum Size of the Cache
+    typed (bool): Same value of different type will be a different entry
+
+    """
+
+    def wrapper_cache(f: Any) -> Any:
+        f = lru_cache(maxsize=maxsize, typed=typed)(f)
+        f.delta = seconds * 10**9
+        f.expiration = monotonic_ns() + f.delta
+
+        @wraps(f)
+        def wrapped_f(*args: Any, **kwargs: Any) -> Any:
+            if monotonic_ns() >= f.expiration:
+                f.cache_clear()
+                f.expiration = monotonic_ns() + f.delta
+            return f(*args, **kwargs)
+
+        wrapped_f.cache_info = f.cache_info  # type: ignore [attr-defined]
+        wrapped_f.cache_clear = f.cache_clear  # type: ignore [attr-defined]
+        return wrapped_f
+
+    # To allow decorator to be used without arguments
+    if _func is None:
+        return wrapper_cache
+    else:
+        return wrapper_cache(_func)

--- a/peakina/io/ftp/ftp_fetcher.py
+++ b/peakina/io/ftp/ftp_fetcher.py
@@ -1,12 +1,13 @@
 import os
-from functools import lru_cache
 from typing import IO, Any
+
+from peakina.cache import timed_lru_cache
 
 from ..fetcher import Fetcher, register
 from .ftp_utils import FTP_SCHEMES, dir_mtimes, ftp_mtime, ftp_open
 
 
-@lru_cache(maxsize=3)
+@timed_lru_cache(maxsize=3, seconds=60)  # type: ignore [misc]
 def _get_mtimes_cache(**kwargs: Any) -> dict[str, dict[str, int | None]]:
     """
     This function allows to share a common _mtime_cache object between several

--- a/peakina/io/ftp/ftp_fetcher.py
+++ b/peakina/io/ftp/ftp_fetcher.py
@@ -1,15 +1,26 @@
 import os
+from functools import lru_cache
 from typing import IO, Any
 
 from ..fetcher import Fetcher, register
 from .ftp_utils import FTP_SCHEMES, dir_mtimes, ftp_mtime, ftp_open
 
 
+@lru_cache(maxsize=3)
+def _get_mtimes_cache(**kwargs: Any) -> dict[str, dict[str, int | None]]:
+    """
+    This function allows to share a common _mtime_cache object between several
+    FTPFetcher objects, as long as they were instanciating with the same params.
+    """
+    _mtimes_cache: dict[str, dict[str, int | None]] = {}
+    return _mtimes_cache
+
+
 @register(schemes=FTP_SCHEMES)
 class FTPFetcher(Fetcher):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self._mtimes_cache: dict[str, dict[str, int | None]] = {}
+        self._mtimes_cache: dict[str, dict[str, int | None]] = _get_mtimes_cache(**kwargs)
 
     def get_dir_mtimes(self, dirpath: str) -> dict[str, int | None]:
         if dirpath not in self._mtimes_cache:

--- a/peakina/io/ftp/ftp_fetcher.py
+++ b/peakina/io/ftp/ftp_fetcher.py
@@ -1,13 +1,13 @@
 import os
 from typing import IO, Any
 
-from peakina.cache import timed_lru_cache
-
 from ..fetcher import Fetcher, register
 from .ftp_utils import FTP_SCHEMES, dir_mtimes, ftp_mtime, ftp_open
 
+# from peakina.cache import timed_lru_cache
 
-@timed_lru_cache(maxsize=3, seconds=60)  # type: ignore [misc]
+
+# @timed_lru_cache(maxsize=3, seconds=60)  # type: ignore [misc]
 def _get_mtimes_cache(**kwargs: Any) -> dict[str, dict[str, int | None]]:
     """
     This function allows to share a common _mtime_cache object between several

--- a/tests/io/ftp/test_ftp_fetcher.py
+++ b/tests/io/ftp/test_ftp_fetcher.py
@@ -4,7 +4,7 @@ from peakina.io.ftp import ftp_fetcher
 
 
 def test_ftp_fetcher(mocker, ftp_path):
-    ftp_fetcher._get_mtimes_cache.cache_clear()
+    # ftp_fetcher._get_mtimes_cache.cache_clear()
     fetcher = ftp_fetcher.FTPFetcher()
     mtime_spy = mocker.spy(ftp_fetcher, "ftp_mtime")
 

--- a/tests/io/ftp/test_ftp_fetcher.py
+++ b/tests/io/ftp/test_ftp_fetcher.py
@@ -4,6 +4,7 @@ from peakina.io.ftp import ftp_fetcher
 
 
 def test_ftp_fetcher(mocker, ftp_path):
+    ftp_fetcher._get_mtimes_cache.cache_clear()
     fetcher = ftp_fetcher.FTPFetcher()
     mtime_spy = mocker.spy(ftp_fetcher, "ftp_mtime")
 

--- a/tests/io/ftp/test_ftp_fetcher.py
+++ b/tests/io/ftp/test_ftp_fetcher.py
@@ -22,3 +22,8 @@ def test_ftp_fetcher(mocker, ftp_path):
         assert (mtime := fetcher.mtime(f"{ftp_path}/my_data_{year}.csv")) is not None
         assert mtime > 1e9
     assert mtime_spy.call_count == 0
+
+    # this new fetcher should reuse the same mtime_cache
+    other_fetcher = ftp_fetcher.FTPFetcher()
+    other_fetcher.mtime(myfile_path)
+    assert mtime_spy.call_count == 0  # <- no call


### PR DESCRIPTION
Use `@lru_cache` to share the same instance of `_mtime_cache` between several instances of `FTPFetcher` (iff they were instanciated with the same parameters).
This will avoid unnecessary calls to `ftp.listdir`.
