### PR TITLE
fix: patch for query params in the url we need to be able to extract the type too

### DIFF
--- a/peakina/datasource.py
+++ b/peakina/datasource.py
@@ -50,7 +50,7 @@ class DataSource:
         if self.scheme not in PD_VALID_URLS:
             raise AttributeError(f"Invalid scheme {self.scheme!r}")
 
-        self.type = self.type or detect_type(self.uri, is_regex=bool(self.match))
+        self.type = self.type or detect_type(self.uri.split("?")[0], is_regex=bool(self.match))
 
         validate_kwargs(self.reader_kwargs, self.type)
 

--- a/peakina/datasource.py
+++ b/peakina/datasource.py
@@ -50,7 +50,7 @@ class DataSource:
         if self.scheme not in PD_VALID_URLS:
             raise AttributeError(f"Invalid scheme {self.scheme!r}")
 
-        self.type = self.type or detect_type(self.uri.split("?")[0], is_regex=bool(self.match))
+        self.type = self.type or detect_type(urlparse(self.uri).path, is_regex=bool(self.match))
 
         validate_kwargs(self.reader_kwargs, self.type)
 

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -36,6 +36,7 @@ def test_type():
         DataSource("myfile.csv$")
     assert DataSource("myfile.tsv$", match=MatchEnum.GLOB).type is TypeEnum.CSV
     assert DataSource("myfile.*", match=MatchEnum.GLOB).type is None
+    assert DataSource("http://test.s3.com/myfile.csv?this=is&a=query&string=0").type is TypeEnum.CSV
 
 
 def test_validation_kwargs(mocker):

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -37,6 +37,8 @@ def test_type():
     assert DataSource("myfile.tsv$", match=MatchEnum.GLOB).type is TypeEnum.CSV
     assert DataSource("myfile.*", match=MatchEnum.GLOB).type is None
     assert DataSource("http://test.s3.com/myfile.csv?this=is&a=query&string=0").type is TypeEnum.CSV
+    assert DataSource("s3://bucket/object.xlsx").type is TypeEnum.EXCEL
+    assert DataSource("s3+protocol://bucket/object.json?q=x").type is TypeEnum.JSON
 
 
 def test_validation_kwargs(mocker):

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -38,7 +38,7 @@ def test_type():
     assert DataSource("myfile.*", match=MatchEnum.GLOB).type is None
     assert DataSource("http://test.s3.com/myfile.csv?this=is&a=query&string=0").type is TypeEnum.CSV
     assert DataSource("s3://bucket/object.xlsx").type is TypeEnum.EXCEL
-    assert DataSource("s3+protocol://bucket/object.json?q=x").type is TypeEnum.JSON
+    assert DataSource("s3://bucket/object.json?q=x").type is TypeEnum.JSON
 
 
 def test_validation_kwargs(mocker):


### PR DESCRIPTION
## WHAT

- fix the uri inferring type when there are query params on it