### PR TITLE
fix: forward the session token to s3fs

### DIFF
--- a/peakina/io/s3/s3_utils.py
+++ b/peakina/io/s3/s3_utils.py
@@ -72,7 +72,7 @@ def s3_open(url: str, *, client_kwargs: dict[str, Any] | None = None) -> IO[byte
     """opens a s3 url and returns a file-like object"""
     access_key, secret, bucketname, objectname = parse_s3_url(url)
 
-    if client_kwargs is not None and "session_token" in client_kwargs:
+    if client_kwargs is not None and "session_token" in client_kwargs:  # pragma: no cover
         session_token = client_kwargs.pop("session_token")
         fs = s3fs.S3FileSystem(
             key=access_key, secret=secret, token=session_token, client_kwargs=client_kwargs

--- a/peakina/io/s3/s3_utils.py
+++ b/peakina/io/s3/s3_utils.py
@@ -72,7 +72,7 @@ def s3_open(url: str, *, client_kwargs: dict[str, Any] | None = None) -> IO[byte
     """opens a s3 url and returns a file-like object"""
     access_key, secret, bucketname, objectname = parse_s3_url(url)
 
-    if client_kwargs is not None and "session_token" in client_kwargs:
+    if isinstance(client_kwargs, dict) and "session_token" in client_kwargs:
         session_token = client_kwargs.pop("session_token")
         fs = s3fs.S3FileSystem(
             key=access_key,
@@ -84,7 +84,7 @@ def s3_open(url: str, *, client_kwargs: dict[str, Any] | None = None) -> IO[byte
         fs = s3fs.S3FileSystem(
             key=access_key,
             secret=secret,
-            client_kwargs=client_kwargs or None,
+            client_kwargs=client_kwargs,
         )
 
     path = f"{bucketname}/{objectname}"

--- a/peakina/io/s3/s3_utils.py
+++ b/peakina/io/s3/s3_utils.py
@@ -32,7 +32,7 @@ def parse_s3_url(url: str, file: bool = True) -> tuple[str | None, str | None, s
     scheme = urlchunks.scheme
     assert scheme in S3_SCHEMES, f"{scheme} unsupported, use one of {S3_SCHEMES}"
     assert not urlchunks.params, f"s3 url should not have params, got {urlchunks.params}"
-    # assert not urlchunks.query, f"s3 url should not have query, got {urlchunks.query}"
+    assert not urlchunks.query, f"s3 url should not have query, got {urlchunks.query}"
     assert not urlchunks.fragment, f"s3 url should not have fragment, got {urlchunks.fragment}"
 
     access_key: str | None = None

--- a/peakina/io/s3/s3_utils.py
+++ b/peakina/io/s3/s3_utils.py
@@ -84,7 +84,7 @@ def s3_open(url: str, *, client_kwargs: dict[str, Any] | None = None) -> IO[byte
         fs = s3fs.S3FileSystem(
             key=access_key,
             secret=secret,
-            client_kwargs=client_kwargs,
+            client_kwargs=client_kwargs or None,
         )
 
     path = f"{bucketname}/{objectname}"

--- a/peakina/io/s3/s3_utils.py
+++ b/peakina/io/s3/s3_utils.py
@@ -72,19 +72,26 @@ def s3_open(url: str, *, client_kwargs: dict[str, Any] | None = None) -> IO[byte
     """opens a s3 url and returns a file-like object"""
     access_key, secret, bucketname, objectname = parse_s3_url(url)
 
-    if isinstance(client_kwargs, dict) and "session_token" in client_kwargs:
-        session_token = client_kwargs.pop("session_token")
-        fs = s3fs.S3FileSystem(
-            key=access_key,
-            secret=secret,
-            token=session_token,
-            client_kwargs=client_kwargs,
-        )
+    if isinstance(client_kwargs, dict):
+        if "session_token" in client_kwargs:
+            session_token = client_kwargs.pop("session_token")
+            fs = s3fs.S3FileSystem(
+                key=access_key,
+                secret=secret,
+                token=session_token,
+                client_kwargs=client_kwargs or None,
+            )
+        else:
+            fs = s3fs.S3FileSystem(
+                key=access_key,
+                secret=secret,
+                client_kwargs=client_kwargs,
+            )
     else:
         fs = s3fs.S3FileSystem(
             key=access_key,
             secret=secret,
-            client_kwargs=client_kwargs,
+            client_kwargs=client_kwargs or None,
         )
 
     path = f"{bucketname}/{objectname}"

--- a/peakina/io/s3/s3_utils.py
+++ b/peakina/io/s3/s3_utils.py
@@ -72,13 +72,20 @@ def s3_open(url: str, *, client_kwargs: dict[str, Any] | None = None) -> IO[byte
     """opens a s3 url and returns a file-like object"""
     access_key, secret, bucketname, objectname = parse_s3_url(url)
 
-    if client_kwargs is not None and "session_token" in client_kwargs:  # pragma: no cover
+    if client_kwargs is not None and "session_token" in client_kwargs:
         session_token = client_kwargs.pop("session_token")
         fs = s3fs.S3FileSystem(
-            key=access_key, secret=secret, token=session_token, client_kwargs=client_kwargs
+            key=access_key,
+            secret=secret,
+            token=session_token,
+            client_kwargs=client_kwargs,
         )
     else:
-        fs = s3fs.S3FileSystem(key=access_key, secret=secret, client_kwargs=client_kwargs)
+        fs = s3fs.S3FileSystem(
+            key=access_key,
+            secret=secret,
+            client_kwargs=client_kwargs,
+        )
 
     path = f"{bucketname}/{objectname}"
     ret = tempfile.NamedTemporaryFile(suffix=".s3tmp")

--- a/tests/io/s3/test_s3_fetcher.py
+++ b/tests/io/s3/test_s3_fetcher.py
@@ -55,7 +55,9 @@ def test_s3_fetcher_open_retry(s3_fetcher, s3_endpoint_url, mocker):
     s3_client.upload_file("tests/fixtures/for_retry_0_0.csv", "mybucket", "for_retry_0_0.csv")
 
     class S3FileSystemThatFailsOpen(S3FileSystem):  # type:ignore[misc]
-        def __init__(self, key: str, secret: str, client_kwargs: dict[str, Any]) -> None:
+        def __init__(
+            self, key: str, secret: str, client_kwargs: dict[str, Any], token: str | None
+        ) -> None:
             super().__init__(key=key, secret=secret, client_kwargs=client_kwargs)
             self.invalidated_cache = False
 

--- a/tests/io/s3/test_s3_utils.py
+++ b/tests/io/s3/test_s3_utils.py
@@ -65,11 +65,18 @@ def test_s3_open_with_token(mocker: MockerFixture) -> None:
     s3fs_file_system = mocker.patch("s3fs.S3FileSystem")
     s3fs_file_system.return_value.open.return_value = io.BytesIO(b"a,b\n0,1\n")
     # called with a session_token
-    s3_open("s3://my_key:my_secret@mybucket/file.csv", client_kwargs={"session_token": "xxxx"})
+    s3_open(
+        "s3://my_key:my_secret@mybucket/file.csv",
+        client_kwargs={"something": "else", "session_token": "xxxx"},
+    )
     s3fs_file_system.assert_called_once_with(
-        token="xxxx", secret="my_secret", key="my_key", client_kwargs={}
+        token="xxxx", secret="my_secret", key="my_key", client_kwargs={"something": "else"}
     )
 
     # called with an empty dict
     s3_open("s3://my_key:my_secret@mybucket/file.csv", client_kwargs={})
+    s3fs_file_system.assert_called_with(secret="my_secret", key="my_key", client_kwargs={})
+
+    # called with None
+    s3_open("s3://my_key:my_secret@mybucket/file.csv", client_kwargs=None)
     s3fs_file_system.assert_called_with(secret="my_secret", key="my_key", client_kwargs=None)

--- a/tests/io/s3/test_s3_utils.py
+++ b/tests/io/s3/test_s3_utils.py
@@ -1,6 +1,8 @@
 import io
+from unittest.mock import MagicMock
 
 from pytest import raises
+from pytest_mock import MockerFixture
 
 from peakina.io.s3.s3_utils import parse_s3_url as pu, s3_open
 
@@ -54,3 +56,20 @@ def test_s3_open(mocker):
     logger_mock.info.assert_called_once_with("opening mybucket/file.csv")
     assert tmpfile.name.endswith(".s3tmp")
     assert tmpfile.read() == b"a,b\n0,1\n"
+
+
+def test_s3_open_with_token(mocker: MockerFixture) -> None:
+    tempfile_mock = MagicMock()
+    mocker.patch("tempfile.NamedTemporaryFile", return_value=tempfile_mock)
+    mocker.patch("peakina.io.s3.s3_utils._s3_open_file_with_retries")
+    s3fs_file_system = mocker.patch("s3fs.S3FileSystem")
+    s3fs_file_system.return_value.open.return_value = io.BytesIO(b"a,b\n0,1\n")
+    # called with a session_token
+    s3_open("s3://my_key:my_secret@mybucket/file.csv", client_kwargs={"session_token": "xxxx"})
+    s3fs_file_system.assert_called_once_with(
+        token="xxxx", secret="my_secret", key="my_key", client_kwargs={}
+    )
+
+    # called with an empty dict
+    s3_open("s3://my_key:my_secret@mybucket/file.csv", client_kwargs={})
+    s3fs_file_system.assert_called_with(secret="my_secret", key="my_key", client_kwargs={})

--- a/tests/io/s3/test_s3_utils.py
+++ b/tests/io/s3/test_s3_utils.py
@@ -72,4 +72,4 @@ def test_s3_open_with_token(mocker: MockerFixture) -> None:
 
     # called with an empty dict
     s3_open("s3://my_key:my_secret@mybucket/file.csv", client_kwargs={})
-    s3fs_file_system.assert_called_with(secret="my_secret", key="my_key", client_kwargs={})
+    s3fs_file_system.assert_called_with(secret="my_secret", key="my_key", client_kwargs=None)

--- a/tests/io/s3/test_s3_utils.py
+++ b/tests/io/s3/test_s3_utils.py
@@ -64,13 +64,20 @@ def test_s3_open_with_token(mocker: MockerFixture) -> None:
     mocker.patch("peakina.io.s3.s3_utils._s3_open_file_with_retries")
     s3fs_file_system = mocker.patch("s3fs.S3FileSystem")
     s3fs_file_system.return_value.open.return_value = io.BytesIO(b"a,b\n0,1\n")
-    # called with a session_token
+
+    # called with a session_token and something else
     s3_open(
         "s3://my_key:my_secret@mybucket/file.csv",
         client_kwargs={"something": "else", "session_token": "xxxx"},
     )
     s3fs_file_system.assert_called_once_with(
         token="xxxx", secret="my_secret", key="my_key", client_kwargs={"something": "else"}
+    )
+
+    # called with just the session token
+    s3_open("s3://my_key:my_secret@mybucket/file.csv", client_kwargs={"session_token": "xxxx"})
+    s3fs_file_system.assert_called_with(
+        token="xxxx", secret="my_secret", key="my_key", client_kwargs=None
     )
 
     # called with an empty dict

--- a/tests/io/s3/test_s3_utils.py
+++ b/tests/io/s3/test_s3_utils.py
@@ -82,8 +82,12 @@ def test_s3_open_with_token(mocker: MockerFixture) -> None:
 
     # called with an empty dict
     s3_open("s3://my_key:my_secret@mybucket/file.csv", client_kwargs={})
-    s3fs_file_system.assert_called_with(secret="my_secret", key="my_key", client_kwargs={})
+    s3fs_file_system.assert_called_with(
+        secret="my_secret", key="my_key", token=None, client_kwargs={}
+    )
 
     # called with None
     s3_open("s3://my_key:my_secret@mybucket/file.csv", client_kwargs=None)
-    s3fs_file_system.assert_called_with(secret="my_secret", key="my_key", client_kwargs=None)
+    s3fs_file_system.assert_called_with(
+        secret="my_secret", key="my_key", token=None, client_kwargs=None
+    )


### PR DESCRIPTION
## WHAT

Sometimes, we need to forward the session token given by s3 authentification,
and we need to forward that to the fileSystem, this PR aim to fix that issue.
