### PR TITLE
fix: ftp fetcher test by increasing the timed_lru_cache decorator's time-out

### DIFF
--- a/peakina/cache.py
+++ b/peakina/cache.py
@@ -5,7 +5,7 @@ from enum import Enum
 from functools import lru_cache, wraps
 from pathlib import Path
 from time import monotonic_ns, time
-from typing import Any, TypedDict
+from typing import Any, Callable, TypedDict
 
 import pandas as pd
 
@@ -164,7 +164,7 @@ class HDFCache(Cache):
 # taken from https://gist.github.com/Morreski/c1d08a3afa4040815eafd3891e16b945
 def timed_lru_cache(
     _func: Any = None, *, seconds: int = 600, maxsize: int = 128, typed: bool = False
-) -> Any:
+) -> Callable[..., Any]:
     """Extension of functools lru_cache with a timeout
     Parameters:
     seconds (int): Timeout in seconds to clear the WHOLE cache, default = 10 minutes
@@ -172,7 +172,7 @@ def timed_lru_cache(
     typed (bool): Same value of different type will be a different entry
     """
 
-    def wrapper_cache(f: Any) -> Any:
+    def wrapper_cache(f: Any) -> Callable[..., Any]:
         f = lru_cache(maxsize=maxsize, typed=typed)(f)
         f.delta = seconds * 10**9
         f.expiration = monotonic_ns() + f.delta

--- a/peakina/io/ftp/ftp_fetcher.py
+++ b/peakina/io/ftp/ftp_fetcher.py
@@ -7,7 +7,7 @@ from ..fetcher import Fetcher, register
 from .ftp_utils import FTP_SCHEMES, dir_mtimes, ftp_mtime, ftp_open
 
 
-@timed_lru_cache(maxsize=3, seconds=60)  # type: ignore [misc]
+@timed_lru_cache(maxsize=3, seconds=100)  # type: ignore [misc]
 def get_mtimes_cache(**kwargs: Any) -> dict[str, dict[str, int | None]]:
     """
     This function allows to share a common _mtime_cache object between several

--- a/peakina/io/ftp/ftp_fetcher.py
+++ b/peakina/io/ftp/ftp_fetcher.py
@@ -7,7 +7,7 @@ from ..fetcher import Fetcher, register
 from .ftp_utils import FTP_SCHEMES, dir_mtimes, ftp_mtime, ftp_open
 
 
-@timed_lru_cache(maxsize=3, seconds=120)
+@timed_lru_cache(maxsize=3, seconds=60)
 def get_mtimes_cache(**kwargs: Any) -> dict[str, dict[str, int | None]]:
     """
     This function allows to share a common _mtime_cache object between several

--- a/peakina/io/ftp/ftp_fetcher.py
+++ b/peakina/io/ftp/ftp_fetcher.py
@@ -7,7 +7,7 @@ from ..fetcher import Fetcher, register
 from .ftp_utils import FTP_SCHEMES, dir_mtimes, ftp_mtime, ftp_open
 
 
-@timed_lru_cache(maxsize=3, seconds=100)  # type: ignore [misc]
+@timed_lru_cache(maxsize=3, seconds=120)
 def get_mtimes_cache(**kwargs: Any) -> dict[str, dict[str, int | None]]:
     """
     This function allows to share a common _mtime_cache object between several

--- a/tests/io/ftp/test_ftp_fetcher.py
+++ b/tests/io/ftp/test_ftp_fetcher.py
@@ -1,9 +1,10 @@
 import pandas as pd
+from pytest_mock import MockerFixture
 
 from peakina.io.ftp import ftp_fetcher
 
 
-def test_ftp_fetcher(mocker, ftp_path):
+def test_ftp_fetcher(mocker: MockerFixture, ftp_path: str) -> None:
     ftp_fetcher.get_mtimes_cache.cache_clear()
     fetcher = ftp_fetcher.FTPFetcher()
     mtime_spy = mocker.spy(ftp_fetcher, "ftp_mtime")

--- a/tests/io/ftp/test_ftp_fetcher.py
+++ b/tests/io/ftp/test_ftp_fetcher.py
@@ -14,11 +14,15 @@ def test_ftp_fetcher(mocker: MockerFixture, ftp_path: str) -> None:
     tmpfile = fetcher.open(myfile_path)
     assert pd.read_csv(tmpfile).shape == (2, 2)
 
+    mocker.patch("peakina.io.ftp.ftp_fetcher.get_mtimes_cache", return_value={"something": "else"})
     assert (mtime := fetcher.mtime(myfile_path)) is not None
     assert mtime > 1e9
     assert mtime_spy.call_count == 1
 
     mtime_spy.reset_mock()
+    mocker.patch(
+        "peakina.io.ftp.ftp_fetcher.get_mtimes_cache", return_value={ftp_path: {myfile: 1e95}}
+    )
     assert myfile in fetcher.listdir(ftp_path)  # gets all mtimes
     for year in range(2015, 2018):
         assert (mtime := fetcher.mtime(f"{ftp_path}/my_data_{year}.csv")) is not None


### PR DESCRIPTION
## WHAT

Fix the flaky test on ftp-fetcher by increasing the seconds on the lru_cache decorator.
EDIT: mock the return of `get_mtimes_cache` 

## WHY

This bug was not reproducible locally because... we have "good" computers... 😄 ... while the CI's computer... is not so performant(CPU/RAM)... that means, sometimes, when the test was taking too long, the cache from the `timed_lru_cache` decorator which was `60s` before was too short, so I increased that to 120s on this PR.

EDIT: 120s is too long, we changed the approach by mocking the return of the function  `get_mtimes_cache`