### PR TITLE
fix: connection dropped for refresh-data [TCTC-6839]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Fixed
+
+- FTP: retry connection on `SSHException` while opening a remote url.
+
 ## [0.9.5] - 2023-04-19
 
 ### Added

--- a/peakina/io/ftp/ftp_utils.py
+++ b/peakina/io/ftp/ftp_utils.py
@@ -16,7 +16,7 @@ from urllib.parse import ParseResult, quote, unquote, urlparse
 import paramiko
 
 FTP_SCHEMES = ["ftp", "ftps", "sftp"]
-_DEFAULT_MAX_TIMEOUT = 10
+_DEFAULT_MAX_TIMEOUT_SECONDS = 10
 _DEFAULT_MAX_RETRY = 7
 
 FTPClient = ftplib.FTP | paramiko.SFTPClient
@@ -75,7 +75,9 @@ class FTPS(ftplib.FTP_TLS):
 def ftps_client(params: ParseResult) -> Generator[tuple[FTPS, str], None, None]:
     ftps = FTPS()
     try:
-        ftps.connect(host=params.hostname or "", port=params.port, timeout=_DEFAULT_MAX_TIMEOUT)
+        ftps.connect(
+            host=params.hostname or "", port=params.port, timeout=_DEFAULT_MAX_TIMEOUT_SECONDS
+        )
         try:
             ftps.prot_p()
             ftps.login(user=params.username or "", passwd=params.password or "")
@@ -99,7 +101,7 @@ def ftp_client(params: ParseResult) -> Generator[tuple[ftplib.FTP, str], None, N
     port = params.port or 21
     ftp = ftplib.FTP()
     try:
-        ftp.connect(host=params.hostname or "", port=port, timeout=_DEFAULT_MAX_TIMEOUT)
+        ftp.connect(host=params.hostname or "", port=port, timeout=_DEFAULT_MAX_TIMEOUT_SECONDS)
         ftp.login(user=params.username or "", passwd=params.password or "")
         yield ftp, params.path
 
@@ -119,7 +121,7 @@ def sftp_client(params: ParseResult) -> Generator[tuple[paramiko.SFTPClient, str
             username=params.username,
             password=params.password,
             port=port,
-            timeout=_DEFAULT_MAX_TIMEOUT,
+            timeout=_DEFAULT_MAX_TIMEOUT_SECONDS,
         )
         sftp = ssh_client.open_sftp()
         yield sftp, params.path

--- a/peakina/io/ftp/ftp_utils.py
+++ b/peakina/io/ftp/ftp_utils.py
@@ -17,7 +17,7 @@ from urllib.parse import ParseResult, quote, unquote, urlparse
 import paramiko
 
 FTP_SCHEMES = ["ftp", "ftps", "sftp"]
-_DEFAULT_MAX_TIMEOUT_SECONDS = 10
+_DEFAULT_MAX_TIMEOUT_SECONDS = 180
 _DEFAULT_MAX_RETRY = 7
 
 FTPClient = ftplib.FTP | paramiko.SFTPClient

--- a/peakina/io/ftp/ftp_utils.py
+++ b/peakina/io/ftp/ftp_utils.py
@@ -125,7 +125,9 @@ def sftp_client(params: ParseResult) -> Generator[tuple[paramiko.SFTPClient, str
         yield sftp, params.path
 
     finally:
-        ssh_client.close()
+        # In cae of Exception, we don't want to raise it
+        with suppress(AttributeError):
+            ssh_client.close()
 
 
 def _urlparse(url: str) -> ParseResult:

--- a/peakina/io/ftp/ftp_utils.py
+++ b/peakina/io/ftp/ftp_utils.py
@@ -130,6 +130,7 @@ def sftp_client(params: ParseResult) -> Generator[tuple[paramiko.SFTPClient, str
     finally:
         # In cae of Exception, we don't want to raise it
         with suppress(AttributeError):
+            logging.getLogger(__name__).warning("Unable to close the Connection the SSHConnection.")
             ssh_client.close()
 
 

--- a/peakina/io/ftp/ftp_utils.py
+++ b/peakina/io/ftp/ftp_utils.py
@@ -190,28 +190,30 @@ def ftp_open(url: str, retry: int = _DEFAULT_MAX_RETRY) -> IO[bytes]:  # type: i
         try:
             return _open(url)
         except (AttributeError, OSError, ftplib.error_temp) as e:
+            log = logging.getLogger(__name__)
             # If this occurs, we need to see what's actually inside that dir
             # by listing maxi 15 entries
             # TODO: remove this after the debuging is done !
-            # FileNotFoundError inerits from OSError
+            # FileNotFoundError inherits from OSError
             if isinstance(e, FileNotFoundError) and not file_listed:  # pragma: no cover
                 try:
+                    file_path = url.split("/")[-1]
                     full_path = "/".join(url.split(":")[-1].split("/")[1:])
-                    logging.getLogger(__name__).warning(f"'{full_path}' not found !")
+                    dir_path = full_path.replace(full_path.split("/")[-1], "")
+                    log.warning(f"File '{file_path}' not available inside : '{dir_path}' !")
 
                     parsed_url = urllib.parse.urlsplit(url)
                     path_without_file = parsed_url.path.rsplit("/", 1)[0]
                     modified_url = urllib.parse.urlunsplit(
                         (parsed_url.scheme, parsed_url.netloc, path_without_file, "", "")
                     )
+
                     files_available = ", ".join(ftp_listdir(modified_url)[:15])
                     # we list only 15 as maximum
-                    logging.getLogger(__name__).warning(
-                        f"Listing files availables > ({files_available})"
-                    )
+                    log.warning(f"List of files : ({files_available})")
                     file_listed = True
                 except Exception as exp:
-                    logging.getLogger(__name__).error(exp)
+                    logging.getLogger(__name__).error(f"Exception on file listing :: {exp}")
             else:
                 sleep_time = 2 * i**2
                 logging.getLogger(__name__).warning(

--- a/peakina/io/ftp/ftp_utils.py
+++ b/peakina/io/ftp/ftp_utils.py
@@ -1,10 +1,10 @@
 import ftplib
 import logging
+import os
 import re
 import socket
 import ssl
 import tempfile
-import urllib.parse
 from contextlib import contextmanager, suppress
 from datetime import datetime
 from functools import partial
@@ -17,7 +17,7 @@ from urllib.parse import ParseResult, quote, unquote, urlparse
 import paramiko
 
 FTP_SCHEMES = ["ftp", "ftps", "sftp"]
-_DEFAULT_MAX_TIMEOUT_SECONDS = 180
+_DEFAULT_MAX_TIMEOUT_SECONDS = 30
 _DEFAULT_MAX_RETRY = 7
 
 FTPClient = ftplib.FTP | paramiko.SFTPClient
@@ -185,41 +185,23 @@ def _open(url: str) -> IO[bytes]:
 
 
 def ftp_open(url: str, retry: int = _DEFAULT_MAX_RETRY) -> IO[bytes]:  # type: ignore
-    file_listed: bool = False
     for i in range(1, retry + 1):
         try:
             return _open(url)
         except (AttributeError, OSError, ftplib.error_temp, paramiko.SSHException) as e:
             log = logging.getLogger(__name__)
-            # If this occurs, we need to see what's actually inside that dir
-            # by listing maxi 15 entries
-            # TODO: remove this after the debuging is done !
+
             # FileNotFoundError inherits from OSError
-            if isinstance(e, FileNotFoundError) and not file_listed:  # pragma: no cover
-                try:
-                    file_path = url.split("/")[-1]
-                    full_path = "/".join(url.split(":")[-1].split("/")[1:])
-                    dir_path = full_path.replace(full_path.split("/")[-1], "")
-                    log.warning(f"File '{file_path}' not available inside : '{dir_path}' !")
-
-                    parsed_url = urllib.parse.urlsplit(url)
-                    path_without_file = parsed_url.path.rsplit("/", 1)[0]
-                    modified_url = urllib.parse.urlunsplit(
-                        (parsed_url.scheme, parsed_url.netloc, path_without_file, "", "")
-                    )
-
-                    files_available = ", ".join(ftp_listdir(modified_url)[:15])
-                    # we list only 15 as maximum
-                    log.warning(f"List of files : ({files_available})")
-                    file_listed = True
-                except Exception as exp:
-                    logging.getLogger(__name__).error(f"Exception on file listing :: {exp}")
-            else:
-                sleep_time = 2 * i**2
-                logging.getLogger(__name__).warning(
-                    f"Retry #{i}: Sleeping {sleep_time}s because {e}"
+            # We need to log that we're not seeing the specified file
+            if isinstance(e, FileNotFoundError):  # pragma: no cover
+                log.warning(
+                    f"File '{os.path.basename(url)}' not available inside : "
+                    f"'{os.path.dirname(urlparse(url).path)}' !"
                 )
-                sleep(sleep_time)
+
+            sleep_time = 2 * i**2
+            logging.getLogger(__name__).warning(f"Retry #{i}: Sleeping {sleep_time}s because {e}")
+            sleep(sleep_time)
 
 
 def _get_all_files(c: FTPClient, path: str) -> list[str]:

--- a/peakina/io/ftp/ftp_utils.py
+++ b/peakina/io/ftp/ftp_utils.py
@@ -189,7 +189,7 @@ def ftp_open(url: str, retry: int = _DEFAULT_MAX_RETRY) -> IO[bytes]:  # type: i
     for i in range(1, retry + 1):
         try:
             return _open(url)
-        except (AttributeError, OSError, ftplib.error_temp) as e:
+        except (AttributeError, OSError, ftplib.error_temp, paramiko.SSHException) as e:
             log = logging.getLogger(__name__)
             # If this occurs, we need to see what's actually inside that dir
             # by listing maxi 15 entries

--- a/peakina/readers/excel.py
+++ b/peakina/readers/excel.py
@@ -17,7 +17,6 @@ def read_excel(
     preview_offset: int = 0,
     **kwargs: Any,
 ) -> pd.DataFrame:
-
     df_or_dict: dict[str, pd.DataFrame] | pd.DataFrame = pd.read_excel(*args, **kwargs)
 
     if isinstance(df_or_dict, dict):  # multiple sheets

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,7 +143,6 @@ def container_starter(request, docker, docker_pull):
         skip_exception=None,
         timeout=None,
     ):
-
         if docker_pull:
             print(f"Pulling {image} image")
             docker.pull(image)

--- a/tests/io/ftp/test_ftp_utils.py
+++ b/tests/io/ftp/test_ftp_utils.py
@@ -198,3 +198,16 @@ def test_sftp_client(mocker):
     url = "sftp://id#de@me*de:randompass@atat.com:666"
     ftp_listdir(url)
     cl_ftp.listdir.assert_called_once_with(".")
+
+
+def test_sftp_client_silent_close(mocker: MockFixture) -> None:
+    invalid_params = ParseResult(scheme="", netloc="", path="", params="", query="", fragment="")
+    ssh_client = mocker.patch("paramiko.SSHClient")
+    ssh_client.return_value.close.side_effect = AttributeError("NoneType doesnt have .close()")
+
+    with sftp_client(invalid_params) as (sftp, _):
+        # This block should raise an exception due to invalid parameters
+        # The exception is expected to be suppressed by the context manager in the finally block
+        # So, the test will pass if no exception propagates beyond this point
+
+        assert sftp.get_channel()

--- a/tests/io/ftp/test_ftp_utils.py
+++ b/tests/io/ftp/test_ftp_utils.py
@@ -4,6 +4,7 @@ import socket
 import ssl
 from urllib.parse import ParseResult
 
+from paramiko.ssh_exception import SSHException
 from pytest import fixture, raises
 from pytest_mock import MockFixture
 
@@ -68,6 +69,7 @@ def test_retry_open(mocker):
         ftplib.error_temp("421 Could not create socket"),
         AttributeError("'NoneType' object has no attribute 'sendall'"),
         OSError("Random OSError"),
+        SSHException("Random connection dropped error"),
         "ok",
     ]
     mock_sleep = mocker.patch("peakina.io.ftp.ftp_utils.sleep")

--- a/tests/io/ftp/test_ftp_utils.py
+++ b/tests/io/ftp/test_ftp_utils.py
@@ -8,7 +8,7 @@ from pytest import fixture, raises
 from pytest_mock import MockFixture
 
 from peakina.io.ftp.ftp_utils import (
-    _DEFAULT_MAX_TIMEOUT,
+    _DEFAULT_MAX_TIMEOUT_SECONDS,
     dir_mtimes,
     ftp_listdir,
     ftp_mtime,
@@ -112,7 +112,7 @@ def test_ftp_client(mocker):
     ftp_open(url)
 
     mock_ftp_client.connect.assert_called_once_with(
-        host="ondine.com", port=123, timeout=_DEFAULT_MAX_TIMEOUT
+        host="ondine.com", port=123, timeout=_DEFAULT_MAX_TIMEOUT_SECONDS
     )
     mock_ftp_client.login.assert_called_once_with(passwd="", user="sacha")
     mock_ftp_client.quit.assert_called_once()
@@ -134,7 +134,7 @@ def test_ftps_client(mocker):
     ftp_open(url)
 
     mock_ftps_client.connect.assert_called_once_with(
-        host="ondine.com", port=123, timeout=_DEFAULT_MAX_TIMEOUT
+        host="ondine.com", port=123, timeout=_DEFAULT_MAX_TIMEOUT_SECONDS
     )
     mock_ftps_client.login.assert_called_once_with(passwd="", user="sacha")
     mock_ftps_client.quit.assert_called_once()
@@ -180,7 +180,7 @@ def test_sftp_client(mocker):
     ftp_open(url)
 
     mock_ssh_client.connect.assert_called_once_with(
-        timeout=_DEFAULT_MAX_TIMEOUT,
+        timeout=_DEFAULT_MAX_TIMEOUT_SECONDS,
         hostname="atat.com",
         port=666,
         username="id#de@me*de",

--- a/tests/io/ftp/test_ftp_utils.py
+++ b/tests/io/ftp/test_ftp_utils.py
@@ -2,10 +2,19 @@ import ftplib
 import os
 import socket
 import ssl
+from urllib.parse import ParseResult
 
 from pytest import fixture, raises
+from pytest_mock import MockFixture
 
-from peakina.io.ftp.ftp_utils import dir_mtimes, ftp_listdir, ftp_mtime, ftp_open
+from peakina.io.ftp.ftp_utils import (
+    _DEFAULT_MAX_TIMEOUT,
+    dir_mtimes,
+    ftp_listdir,
+    ftp_mtime,
+    ftp_open,
+    sftp_client,
+)
 
 
 @fixture
@@ -102,7 +111,9 @@ def test_ftp_client(mocker):
     url = "ftp://sacha@ondine.com:123/picha/chu.csv"
     ftp_open(url)
 
-    mock_ftp_client.connect.assert_called_once_with(host="ondine.com", port=123, timeout=3)
+    mock_ftp_client.connect.assert_called_once_with(
+        host="ondine.com", port=123, timeout=_DEFAULT_MAX_TIMEOUT
+    )
     mock_ftp_client.login.assert_called_once_with(passwd="", user="sacha")
     mock_ftp_client.quit.assert_called_once()
 
@@ -122,7 +133,9 @@ def test_ftps_client(mocker):
     url = "ftps://sacha@ondine.com:123/picha/chu.csv"
     ftp_open(url)
 
-    mock_ftps_client.connect.assert_called_once_with(host="ondine.com", port=123, timeout=3)
+    mock_ftps_client.connect.assert_called_once_with(
+        host="ondine.com", port=123, timeout=_DEFAULT_MAX_TIMEOUT
+    )
     mock_ftps_client.login.assert_called_once_with(passwd="", user="sacha")
     mock_ftps_client.quit.assert_called_once()
 
@@ -167,7 +180,11 @@ def test_sftp_client(mocker):
     ftp_open(url)
 
     mock_ssh_client.connect.assert_called_once_with(
-        timeout=3, hostname="atat.com", port=666, username="id#de@me*de", password="randompass"
+        timeout=_DEFAULT_MAX_TIMEOUT,
+        hostname="atat.com",
+        port=666,
+        username="id#de@me*de",
+        password="randompass",
     )
     mock_ssh_client.open_sftp.assert_called_once()
     mock_ssh_client.close.assert_called_once()


### PR DESCRIPTION
## WHAT

`connection dropped` on remote file (SFTP).
This is not a "new issue", my proposition on this PR is to increase the timeout, the retry and
suppress the .close() error and let see on live prod how it behave.
+ add more logging information.

## HOW

- feat: increase timeout values and the retry amount
- fix: suppress the .close error for None type ?
- chore: add more logs while accessing the remote SFTP file.
