### PR TITLE
Revert "build(deps): bump codecov/codecov-action from 3 to 4 (#582)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,4 +82,4 @@ jobs:
         PYDANTIC_VERSION: ${{ matrix.pydantic-version }}
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3


### PR DESCRIPTION
## WHAT

This reverts commit 518939d4b6e7c8b70f08c6dee2e35d163d87781b.

## WHY

This is making all other dependabot PR fails, and should be downgrade to v3
