### PR TITLE
fix: As an AB I can't skip rows based on “Line numbers to skip (0-indexed)[TCTC-7097]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 
+- Csv: fix get-metadatas from CSVs files with `skiprows` as list (0-indexed) in Datasource.
 - FTP: retry connection on `SSHException` while opening a remote url.
 
 ## [0.12.0] - 2023-09-01

--- a/peakina/readers/csv.py
+++ b/peakina/readers/csv.py
@@ -101,7 +101,11 @@ def csv_meta(
             "df_rows": reader_kwargs["nrows"],
         }
 
-    start = 0 + reader_kwargs.get("skiprows", 0)
+    skiprows = reader_kwargs.get("skiprows", 0)
+    if isinstance(skiprows, list):
+        skiprows = len(skiprows)
+
+    start = 0 + skiprows
     end = total_rows - reader_kwargs.get("skipfooter", 0)
 
     preview_offset = reader_kwargs.get("preview_offset", 0)

--- a/peakina/readers/csv.py
+++ b/peakina/readers/csv.py
@@ -27,6 +27,11 @@ def read_csv(
     """
     The read_csv method is able to make a preview by reading on chunks
     """
+
+    # NOTE: To keep column-names in the final result
+    if isinstance(kwargs.get("skiprows", None), list):
+        kwargs["skiprows"] = [x + 1 for x in kwargs["skiprows"]]
+
     if preview_nrows is not None or preview_offset:
         if (skipfooter := kwargs.pop("skipfooter", None)) is None:
             skipfooter = 0

--- a/tests/readers/test_csv.py
+++ b/tests/readers/test_csv.py
@@ -51,6 +51,26 @@ def test_simple_csv_preview(path):
     assert ds.get_df().shape == (2, 2)
     assert ds.get_df().equals(pd.DataFrame({"month": ["Mars-14", "Avr-14"], "value": [3.3, 3.1]}))
 
+    # with skiprows as list
+    ds = DataSource(
+        path("fixture-1.csv"),
+        reader_kwargs={"skiprows": [1, 2, 5, 7, 9, 11, 12]},
+    )
+    assert ds.get_df().equals(
+        pd.DataFrame(
+            {
+                "month": {
+                    0: "Mars-14",
+                    1: "Avr-14",
+                    2: "Juin-14",
+                    3: "Aout-14",
+                    4: "Oct-14",
+                },
+                "value": {0: 3.3, 1: 3.1, 2: 3.4, 3: 3.2, 4: 3.8},
+            }
+        )
+    )
+
 
 def test_csv_metadata(path):
     """

--- a/tests/readers/test_csv.py
+++ b/tests/readers/test_csv.py
@@ -54,19 +54,20 @@ def test_simple_csv_preview(path):
     # with skiprows as list
     ds = DataSource(
         path("fixture-1.csv"),
-        reader_kwargs={"skiprows": [1, 2, 5, 7, 9, 11, 12]},
+        reader_kwargs={"skiprows": [0, 2, 5, 7, 9, 11, 12]},
     )
     assert ds.get_df().equals(
         pd.DataFrame(
             {
                 "month": {
-                    0: "Mars-14",
+                    0: "Fev-14",
                     1: "Avr-14",
-                    2: "Juin-14",
-                    3: "Aout-14",
-                    4: "Oct-14",
+                    2: "Mai-14",
+                    3: "Juil-14",
+                    4: "Sept-14",
+                    5: "Nov-14",
                 },
-                "value": {0: 3.3, 1: 3.1, 2: 3.4, 3: 3.2, 4: 3.8},
+                "value": {0: 3.2, 1: 3.1, 2: 3.9, 3: 3.1, 4: 3.4, 5: 3.7},
             }
         )
     )

--- a/tests/readers/test_csv.py
+++ b/tests/readers/test_csv.py
@@ -75,9 +75,21 @@ def test_csv_metadata(path):
         "total_rows": 12,
     }
 
+    # skiprows as integer
     ds = DataSource(
         path("fixture-1.csv"),
         reader_kwargs={"skiprows": 3, "skipfooter": 4},
+    )
+    assert ds.get_df().shape == (5, 2)
+    assert ds.get_metadata() == {
+        "df_rows": 5,
+        "total_rows": 12,
+    }
+
+    # skiprows as list
+    ds = DataSource(
+        path("fixture-1.csv"),
+        reader_kwargs={"skiprows": [0, 2, 4], "skipfooter": 4},
     )
     assert ds.get_df().shape == (5, 2)
     assert ds.get_metadata() == {


### PR DESCRIPTION
## WHAT

We can provide skiprows as a list and still extract content from csv file.
The previous implementation presupposed, that value will always be an integer.

## WHY

This resolves : https://toucantoco.atlassian.net/browse/TCTC-7097

## HOW

- skiprows can be a given list
- adapt tests for csv_meta changes

## ADDITIONAL INFOS

### DEMO

#### BEFORE


https://github.com/ToucanToco/peakina/assets/22576758/4f6f14ec-f482-4f9c-925b-b547bd2223b8



#### AFTER

https://github.com/ToucanToco/peakina/assets/22576758/0022756b-c1b8-4dc2-a94c-1e826082a1e8


**NOTE:** A backport sur LTS, je viens de spot le meme soucis.
