### PR TITLE
chore: bump peakina from 0.12.0 to 0.12.1 [TCTC-7097]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [0.12.1] - 2023-11-15
+
 ### Fixed
 
 - Csv: fix get-metadatas from CSVs files with `skiprows` as list (0-indexed) in Datasource.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "peakina"
-version = "0.12.0"
+version = "0.12.1"
 description = "pandas readers on steroids (remote files, glob patterns, cache, etc.)"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 readme = "README.md"


### PR DESCRIPTION
## WHAT

This pr includes :
- a fix for the skiprows on list : https://github.com/ToucanToco/peakina/pull/638
-  the backport for connection dropped : https://github.com/ToucanToco/peakina/pull/606
