### PR TITLE
backport(fix-csv): As an AB I can't skip rows based on “Line numbers to skip (0-indexed)[TCTC-7097] (#638)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Csv: fix get-metadatas from CSVs files with `skiprows` as list (0-indexed) in Datasource.
 - FTP: retry connection on `SSHException` while opening a remote url.
 
 ## [0.9.5] - 2023-04-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## [0.9.6] - 2023-10-13
 
 ### Fixed
 
 - Csv: fix get-metadatas from CSVs files with `skiprows` as list (0-indexed) in Datasource.
+
+## [0.9.6] - 2023-10-13
+
+### Fixed
+
 - FTP: retry connection on `SSHException` while opening a remote url.
 
 ## [0.9.5] - 2023-04-19

--- a/peakina/readers/csv.py
+++ b/peakina/readers/csv.py
@@ -27,6 +27,11 @@ def read_csv(
     """
     The read_csv method is able to make a preview by reading on chunks
     """
+
+    # NOTE: To keep column-names in the final result
+    if isinstance(kwargs.get("skiprows", None), list):
+        kwargs["skiprows"] = [x + 1 for x in kwargs["skiprows"]]
+
     if preview_nrows is not None or preview_offset:
         if (skipfooter := kwargs.pop("skipfooter", None)) is None:
             skipfooter = 0
@@ -101,7 +106,11 @@ def csv_meta(
             "df_rows": reader_kwargs["nrows"],
         }
 
-    start = 0 + reader_kwargs.get("skiprows", 0)
+    skiprows = reader_kwargs.get("skiprows", 0)
+    if isinstance(skiprows, list):
+        skiprows = len(skiprows)
+
+    start = 0 + skiprows
     end = total_rows - reader_kwargs.get("skipfooter", 0)
 
     preview_offset = reader_kwargs.get("preview_offset", 0)

--- a/tests/readers/test_csv.py
+++ b/tests/readers/test_csv.py
@@ -51,6 +51,27 @@ def test_simple_csv_preview(path):
     assert ds.get_df().shape == (2, 2)
     assert ds.get_df().equals(pd.DataFrame({"month": ["Mars-14", "Avr-14"], "value": [3.3, 3.1]}))
 
+    # with skiprows as list
+    ds = DataSource(
+        path("fixture-1.csv"),
+        reader_kwargs={"skiprows": [0, 2, 5, 7, 9, 11, 12]},
+    )
+    assert ds.get_df().equals(
+        pd.DataFrame(
+            {
+                "month": {
+                    0: "Fev-14",
+                    1: "Avr-14",
+                    2: "Mai-14",
+                    3: "Juil-14",
+                    4: "Sept-14",
+                    5: "Nov-14",
+                },
+                "value": {0: 3.2, 1: 3.1, 2: 3.9, 3: 3.1, 4: 3.4, 5: 3.7},
+            }
+        )
+    )
+
 
 def test_csv_metadata(path):
     """
@@ -75,9 +96,21 @@ def test_csv_metadata(path):
         "total_rows": 12,
     }
 
+    # skiprows as integer
     ds = DataSource(
         path("fixture-1.csv"),
         reader_kwargs={"skiprows": 3, "skipfooter": 4},
+    )
+    assert ds.get_df().shape == (5, 2)
+    assert ds.get_metadata() == {
+        "df_rows": 5,
+        "total_rows": 12,
+    }
+
+    # skiprows as list
+    ds = DataSource(
+        path("fixture-1.csv"),
+        reader_kwargs={"skiprows": [0, 2, 4], "skipfooter": 4},
     )
     assert ds.get_df().shape == (5, 2)
     assert ds.get_metadata() == {


### PR DESCRIPTION
## WHAT

A backport of https://github.com/ToucanToco/peakina/pull/638

## HOW

* fix: skiprows can be a given list
* feat: adapt tests for csv_meta changes
* feat: to keep the 0-indexed feature
* chore(doc): update the CHANGELOG
* feat: to keep column names, even with the provided 0-indexed values
